### PR TITLE
feat: add sessionToken in AwsConfig input

### DIFF
--- a/src/types/AwsConfigITC.ts
+++ b/src/types/AwsConfigITC.ts
@@ -5,6 +5,7 @@ export default schemaComposer.createInputTC({
   fields: {
     accessKeyId: 'String',
     secretAccessKey: 'String',
+    sessionToken: 'String',
     region: 'String',
   },
 });


### PR DESCRIPTION
Allows passing a `sessionToken` along with `accessKeyId` and `secretAccessKey`